### PR TITLE
fix warn_one in ForeachAdamC

### DIFF
--- a/heavyball/__init__.py
+++ b/heavyball/__init__.py
@@ -122,7 +122,7 @@ class ForeachAdamC(C.BaseOpt):
         **kwargs,
     ):
         if max_lr is None:
-            utils.warn_one(
+            utils.warn_once(
                 "max_lr was not set. setting it to the current learning rate, under the assumption that it strictly decreases"
             )
             max_lr = lr


### PR DESCRIPTION
"warn_once" snuck in to ForeachAdamC as "warn_one" :) 

https://github.com/HomebrewML/HeavyBall/blob/14e68a880c57e7020ac02996e58f818783090150/heavyball/__init__.py#L125

