### PR TITLE
Fix ECC correction range: ±0.5 ULP → ±1 ULP

### DIFF
--- a/heavyball/utils.py
+++ b/heavyball/utils.py
@@ -1129,7 +1129,7 @@ class _ULPState:
         self.smax = smax
 
     def decode(self, x):
-        ls = (_log_ulp(x) - 1).float()
+        ls = _log_ulp(x).float()
         return x.float() + _scale_by_exp2(self.correction.float() / self.smax, ls)
 
     @staticmethod
@@ -1141,7 +1141,7 @@ class _ULPState:
     def compute_correction(self, fp32, narrow):
         narrow_f32 = self._bf16_to_f32(narrow) if narrow.dtype == torch.bfloat16 else narrow.float()
         e = fp32 - narrow_f32
-        ls = (_log_ulp(narrow) - 1).float()
+        ls = _log_ulp(narrow).float()
         e_norm = _scale_by_exp2(e, -ls)
         scaled = e_norm.clamp(-1.0, 1.0) * self.smax
         self.correction.copy_(scaled.abs().add(0.5).floor().copysign(scaled).to(self.correction.dtype))

--- a/heavyball/utils.py
+++ b/heavyball/utils.py
@@ -1129,7 +1129,7 @@ class _ULPState:
         self.smax = smax
 
     def decode(self, x):
-        ls = _log_ulp(x).float()
+        ls = (_log_ulp(x) - 1).float()
         return x.float() + _scale_by_exp2(self.correction.float() / self.smax, ls)
 
     @staticmethod
@@ -1141,13 +1141,19 @@ class _ULPState:
     def compute_correction(self, fp32, narrow):
         narrow_f32 = self._bf16_to_f32(narrow) if narrow.dtype == torch.bfloat16 else narrow.float()
         e = fp32 - narrow_f32
-        ls = _log_ulp(narrow).float()
+        ls = (_log_ulp(narrow) - 1).float()
         e_norm = _scale_by_exp2(e, -ls)
         scaled = e_norm.clamp(-1.0, 1.0) * self.smax
-        self.correction.copy_(scaled.abs().add(0.5).floor().copysign(scaled).to(self.correction.dtype))
+        # SR on the int correction — the bits below the correction's resolution.
+        # narrow is RNE so |e| ≤ ULP/2, keeping `scaled` in [-smax, smax]; SR
+        # adds at most 1 unit of correction (= ULP/(2*smax)) of error and is
+        # unbiased on the lowest representable bits.
+        rounded = (scaled + torch.rand_like(scaled)).floor()
+        self.correction.copy_(rounded.to(self.correction.dtype))
 
     def encode(self, fp32, target):
-        # RNE, not stochastic: the correction range assumes |error| ≤ ULP/2.
+        # RNE on the narrow keeps |error| ≤ ULP/2 so the correction range stays
+        # ±ULP/2; SR is applied on the int correction inside compute_correction.
         rounded = fp32.to(target.dtype)
         set_(target, rounded)
         self.compute_correction(fp32, target)

--- a/test/test_ecc.py
+++ b/test/test_ecc.py
@@ -78,7 +78,8 @@ def test_ulp_roundtrip(mode):
     err, naive_err = (x - out).abs(), (x - xn.float()).abs()
     improvement = naive_err.max().item() / max(err.max().item(), 1e-45)
     assert improvement > (100 if cfg.corr_dtype == torch.int8 else 10000)
-    assert (err <= naive_err + 1e-10).all()
+    sr_bound = torch.exp2(utils._log_ulp(xn).float()) / (2 * cfg.smax)
+    assert (err <= sr_bound + 1e-10).all()
 
 
 def test_ecc_boundary_values():
@@ -89,7 +90,8 @@ def test_ecc_boundary_values():
         st = utils._ULPState(ecc, smax)
         st.compute_correction(vals, xn)
         out = st.decode(xn)
-        assert ((vals - out).abs() <= (vals - xn.float()).abs() + 1e-10).all()
+        sr_bound = torch.exp2(utils._log_ulp(xn).float()) / (2 * smax)
+        assert ((vals - out).abs() <= sr_bound + 1e-10).all()
 
 
 @pytest.mark.parametrize("mode", ULP_MODES)


### PR DESCRIPTION
With round to nearest the quantization error is bounded by ±1/2 ULP, hence the logULP-1, however when doing stochastic rounding the error can be larger. E.g. if x is representable in FP32 and BF16, then x+eps will be rounded up with some low probability, and the error between the rounded value and x will be 1 ULP instead of 1/2. 

So, to handle stochastic rounding correctly (the default in HeavyBall), the ECC needs to be computed using ±1ULP. 

Tested with the `precision_toy.py` script from the blogpost

<img width="1440" height="900" alt="precision_toy" src="https://github.com/user-attachments/assets/9d9356d8-0b94-4f7a-bb41-00ea1411dc97" />
