### PR TITLE
Add underscore prefixes to unused parameters

### DIFF
--- a/heavyball/chainable.py
+++ b/heavyball/chainable.py
@@ -529,7 +529,7 @@ def weight_decay_to_init(group, update, grad, param, init):
     return update
 
 
-def identity(state, group, update, grad, param):
+def identity(_state, _group, update, _grad, _param):
     return update
 
 


### PR DESCRIPTION
Wow, this project is super cool! I added underscore prefixes to unused parameters in the identity method within chainable.py. This resolves linter warnings and clarifies that these parameters are intentionally unused. Hope this helps!